### PR TITLE
プロフィール画像のアップロード機能を実装 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,4 +34,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :confirmable, :lockable, :timeoutable, :trackable
+
+  # プロフィール画像の関連付け
+  has_one_attached :avatar
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,53 +1,93 @@
-<%# プロフィール編集ページ全体のコンテナ - 最小の高さを画面いっぱいに設定し、背景色とパディングを設定 %>
+<%# プロフィール編集ページ全体のコンテナ %>
+<%# min-h-screenで最小の高さを画面いっぱいに設定し、背景色とパディングを設定 %>
 <div class="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
   <%# コンテンツの最大幅を制限し、中央寄せに設定 %>
+  <%# max-w-mdで最大幅を設定し、mx-autoで左右の余白を自動調整して中央寄せ %>
   <div class="max-w-md mx-auto">
-    <%# ヘッダーセクション - タイトルと説明文を中央寄せで表示 %>
+    <%# ヘッダーセクション %>
+    <%# text-centerでテキストを中央寄せに設定 %>
     <div class="text-center">
-      <%# メインタイトル - 大きめのフォントで目立つように設定 %>
+      <%# メインタイトル - text-3xlで大きめのフォント、font-extraboldで太字 %>
       <h2 class="text-3xl font-extrabold text-gray-900">
         プロフィール編集
       </h2>
-      <%# サブタイトル - 説明文を小さめのフォントでグレー色に設定 %>
+      <%# サブタイトル - mt-2で上部マージン、text-smで小さめのフォント、text-gray-600でグレー色 %>
       <p class="mt-2 text-sm text-gray-600">
         アカウント情報を更新できます
       </p>
     </div>
 
-    <%# 編集フォーム - Deviseのform_forヘルパーを使用し、PUTメソッドで更新 %>
+    <%# 編集フォーム %>
+    <%# Deviseのform_forヘルパーを使用し、PUTメソッドで更新 %>
+    <%# mt-8で上部マージン、space-y-6で子要素間の垂直方向の間隔を設定 %>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "mt-8 space-y-6" }) do |f| %>
       <%# エラーメッセージ表示用のパーシャル呼び出し %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
-      <%# メールアドレス入力フィールド - ラベルとテキストボックスをグループ化 %>
+      <%# プロフィール画像セクション %>
+      <%# space-y-4で子要素間の垂直方向の間隔を設定 %>
+      <div class="space-y-4">
+        <%# セクションタイトル - text-lgで大きめのフォント %>
+        <h3 class="text-lg font-medium text-gray-900">プロフィール画像</h3>
+        <%# 画像表示エリア - flex items-centerで子要素を中央揃えに %>
+        <div class="flex items-center space-x-4">
+          <%# 現在のプロフィール画像が存在する場合は表示 %>
+          <% if resource.avatar.attached? %>
+            <%# 画像サイズを100x100にリサイズして表示 %>
+            <%= image_tag resource.avatar.variant(resize_to_limit: [100, 100]), class: "h-20 w-20 rounded-full object-cover" %>
+          <% else %>
+            <%# プロフィール画像が未設定の場合はデフォルトのアイコンを表示 %>
+            <div class="h-20 w-20 rounded-full bg-gray-200 flex items-center justify-center">
+              <%# ユーザーアイコンのSVG %>
+              <svg class="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              </svg>
+            </div>
+          <% end %>
+          <%# 画像アップロードフィールド - flex-1で残りの幅を全て使用 %>
+          <div class="flex-1">
+            <%= f.label :avatar, "画像を選択", class: "block text-sm font-medium text-gray-700" %>
+            <%# ファイル選択ボタンのスタイリング %>
+            <%= f.file_field :avatar, class: "mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" %>
+            <%# 画像のガイドライン表示 %>
+            <p class="mt-1 text-sm text-gray-500">
+              推奨サイズ: 400x400px<br>
+              対応形式: JPG, PNG, GIF
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <%# メールアドレス入力フィールド %>
       <div>
-        <%# メールアドレスのラベル %>
         <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700" %>
         <%# メールアドレス入力フィールド - フォーカス時に青色の枠線表示 %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
       </div>
 
-      <%# メール確認待ちの場合の警告表示 - 黄色系の警告ボックス %>
-      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <%# メール確認待ちの警告表示 %>
+      <%# 新しいメールアドレスの確認待ちの場合に表示 %>
+      <% if resource.pending_reconfirmation? %>
+        <%# 警告メッセージボックス - 黄色系の配色 %>
         <div class="rounded-md bg-yellow-50 p-4">
           <div class="flex">
-            <%# 警告アイコン - SVGで「!」マークを表示 %>
+            <%# 警告アイコン %>
             <div class="flex-shrink-0">
               <svg class="h-5 w-5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                 <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
               </svg>
             </div>
-            <%# 確認待ちメールアドレスの表示 %>
+            <%# 警告メッセージ %>
             <div class="ml-3">
               <p class="text-sm text-yellow-700">
-                確認待ちのメールアドレス: <%= resource.unconfirmed_email %>
+                現在、<%= resource.unconfirmed_email %>への確認メールを送信しています。
               </p>
             </div>
           </div>
         </div>
       <% end %>
 
-      <%# パスワード変更セクション - 新パスワード、確認用、現在のパスワードの入力欄をグループ化 %>
+      <%# パスワード変更セクション %>
       <div class="space-y-4">
         <%# セクションタイトル %>
         <h3 class="text-lg font-medium text-gray-900">パスワードの変更</h3>
@@ -74,23 +114,26 @@
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
         </div>
 
-        <%# 現在のパスワード入力フィールド - 変更を確認するために必要 %>
+        <%# 現在のパスワード入力フィールド %>
+        <%# 変更を確認するために必要な認証用フィールド %>
         <div>
           <%= f.label :current_password, "現在のパスワード", class: "block text-sm font-medium text-gray-700" %>
           <%= f.password_field :current_password, autocomplete: "current-password", class: "mt-1 appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" %>
           <p class="mt-2 text-sm text-gray-500">
-            変更を確認するために現在のパスワードを入力してください
+            変更を確認するために、現在のパスワードを入力してください
           </p>
         </div>
       </div>
 
-      <%# 更新ボタン - 青色のプライマリーボタン %>
+      <%# 更新ボタン %>
+      <%# w-fullで幅いっぱい、bg-blue-600で青色の背景、hover:bg-blue-700でホバー時に濃い青色 %>
       <div>
         <%= f.submit "更新する", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
       </div>
     <% end %>
 
-    <%# アカウント削除セクション - 上部にボーダーラインで区切り %>
+    <%# アカウント削除セクション %>
+    <%# mt-8で上部マージン、border-tで上部にボーダーライン %>
     <div class="mt-8 border-t border-gray-200 pt-8">
       <%# セクションタイトル %>
       <h3 class="text-lg font-medium text-gray-900">アカウントの削除</h3>
@@ -98,13 +141,15 @@
       <p class="mt-2 text-sm text-gray-500">
         アカウントを削除すると、すべてのデータが失われます。この操作は取り消すことができません。
       </p>
-      <%# 削除ボタン - 赤色の警告ボタン、確認ダイアログ付き %>
+      <%# 削除ボタン %>
+      <%# bg-red-600で赤色の背景、data-confirmで確認ダイアログを表示 %>
       <div class="mt-4">
         <%= button_to "アカウントを削除", registration_path(resource_name), data: { confirm: "本当にアカウントを削除しますか？", turbo_confirm: "本当にアカウントを削除しますか？" }, method: :delete, class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
       </div>
     </div>
 
-    <%# 戻るリンク - 青色のテキストリンク %>
+    <%# 戻るリンク %>
+    <%# text-blue-600で青色のテキスト、hover:text-blue-500でホバー時に明るい青色 %>
     <div class="mt-6 text-center">
       <%= link_to "戻る", :back, class: "text-sm font-medium text-blue-600 hover:text-blue-500" %>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,44 +1,70 @@
 # Railsアプリケーションの起動に必要な基本設定ファイルを読み込み
+# config/boot.rbには、Bundlerの設定やGemfileの読み込みなどの基本設定が含まれる
 require_relative "boot"
 
 # Railsの全機能を読み込む
-# Active Record、Action Controller、Action View、Action Mailerなどすべてのフレームワークを含む
+# rails/allには以下のような主要なフレームワークが含まれる:
+# - Active Record: データベースとのやり取りを担当するORM
+# - Action Controller: リクエスト処理とルーティングを制御
+# - Action View: ビューテンプレートの描画を担当
+# - Action Mailer: メール送信機能を提供
+# - Active Storage: ファイルアップロード機能を提供
+# - Action Cable: WebSocketによるリアルタイム通信を実現
 require "rails/all"
 
 # Gemfileに記載された全てのgemを環境ごとに読み込む
-# test、development、productionの各環境で必要なgemを自動的に判別
+# Rails.groupsは現在の実行環境(development/test/production)を返す
+# *演算子で配列を展開し、各環境に必要なgemのみを読み込む
 Bundler.require(*Rails.groups)
 
 # アプリケーションの名前空間を定義
+# モジュール名はアプリケーション名と一致させる
 module App
-  # Railsアプリケーションの設定クラス
+  # Railsアプリケーションの主要な設定を行うクラス
+  # Rails::Applicationを継承し、フレームワークの機能を利用可能にする
   class Application < Rails::Application
     # Rails 7.1の初期設定を読み込む
-    # フレームワークのデフォルト値や新機能を有効化
+    # 新しいバージョンで追加された機能や設定を有効化
+    # 互換性を保ちながら新機能を利用可能にする
     config.load_defaults 7.1
 
     # 国際化(i18n)の設定
+    # アプリケーション全体の言語設定を管理
+    
     # デフォルトのロケールを日本語(:ja)に設定
+    # ユーザーが言語を選択していない場合のデフォルト値となる
     config.i18n.default_locale = :ja
+    
     # アプリケーションで使用可能な言語を日本語と英語に制限
+    # システムがサポートする言語を明示的に指定
     config.i18n.available_locales = [ :ja, :en ]
+    
     # 翻訳ファイルの配置場所を指定
     # config/locales以下の全サブディレクトリから.rbと.ymlファイルを読み込む
+    # 言語ファイルを階層的に整理可能にする
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
 
     # libディレクトリの自動読み込み設定
-    # assets、tasksディレクトリは自動読み込みから除外
-    # これらのディレクトリには通常.rbファイルが含まれないため
-    config.autoload_lib(ignore: %w[assets tasks])
+    # アプリケーション固有のライブラリコードを管理
+    # assets: アセットパイプライン関連のファイル
+    # tasks: Rakeタスク
+    # templates: ジェネレータのテンプレート
+    # これらのディレクトリは.rbファイルを含まないため、自動読み込みから除外
+    config.autoload_lib(ignore: %w[assets tasks templates])
 
-    # アプリケーション、エンジン、railtiesの追加設定はここに記述
-    #
-    # これらの設定は環境固有の設定ファイル(config/environments/*)で
-    # 上書きすることが可能
-    #
-    # タイムゾーンの設定例（コメントアウト中）
-    # config.time_zone = "Central Time (US & Canada)"
-    # 追加のautoload pathの設定例（コメントアウト中）
-    # config.eager_load_paths << Rails.root.join("extras")
+    # タイムゾーンを東京に設定
+    # 日時の表示や保存を日本時間で行う
+    config.time_zone = 'Tokyo'
+
+    # Active Storageの設定
+    # ファイルアップロード機能のカスタマイズ
+    
+    # 画像処理にmini_magickを使用
+    # ImageMagickを使用して画像のリサイズなどの処理を行う
+    config.active_storage.variant_processor = :mini_magick
+    
+    # ストレージへのルーティングをプロキシ経由に設定
+    # セキュアなファイルアクセスを実現
+    config.active_storage.resolve_model_to_route = :rails_storage_proxy
   end
 end

--- a/db/migrate/20250326075223_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250326075223_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_23_155407) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_26_075223) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -39,4 +67,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_23_155407) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## 概要
ユーザープロフィールに画像をアップロードできる機能を実装しました。

## 実装内容
- Active Storageの設定とマイグレーションを追加
- Userモデルにプロフィール画像の関連付けを追加
- プロフィール編集フォームに画像アップロード機能を追加
- 画像のリサイズ処理とプレビュー表示を実装

## 技術的な詳細
- Active Storageを使用してファイルアップロードを実装
- mini_magickを使用して画像のリサイズ処理を実装
- 画像は100x100pxにリサイズされ、円形で表示
- 対応フォーマット：JPG, PNG, GIF

## テスト項目
- [ ] プロフィール画像のアップロード
- [ ] 画像のリサイズ処理
- [ ] プレビュー表示
- [ ] バリデーション

## 今後の課題
- 画像のバリデーション機能の追加
- 画像のプレビュー機能の改善
- テストの実装