### PR TITLE
feat: チャットルームモデルとユーザーとの関連付けを実装

### DIFF
--- a/app/models/chat_room.rb
+++ b/app/models/chat_room.rb
@@ -1,0 +1,48 @@
+# チャットルームモデル
+# 学生と投資家のコミュニケーションの場を管理するモデル
+class ChatRoom < ApplicationRecord
+  # ステータス定義
+  # チャットルームの状態を管理するenum
+  # active: 0 - アクティブな（利用可能な）チャットルーム
+  # inactive: 1 - 非アクティブな（利用停止中の）チャットルーム
+  enum status: {
+    active: 0,
+    inactive: 1
+  }
+
+  # バリデーション
+  # name: チャットルーム名
+  #   - 必須項目
+  #   - 最大50文字まで
+  validates :name, presence: true, length: { maximum: 50 }
+  
+  # description: チャットルームの説明文
+  #   - 任意項目
+  #   - 最大500文字まで
+  validates :description, length: { maximum: 500 }
+  
+  # status: チャットルームの状態
+  #   - 必須項目
+  #   - enumで定義された値のみ許可
+  validates :status, presence: true, inclusion: { in: statuses.keys }
+
+  # 関連付け
+  # chat_room_users: 中間テーブル
+  #   - チャットルームとユーザーの多対多の関係を管理
+  #   - チャットルームが削除された場合、関連するレコードも削除
+  has_many :chat_room_users, dependent: :destroy
+  
+  # users: チャットルームに参加しているユーザー
+  #   - chat_room_usersを介して関連付け
+  has_many :users, through: :chat_room_users
+  
+  # messages: チャットルーム内のメッセージ
+  #   - チャットルームが削除された場合、関連するメッセージも削除
+  has_many :messages, dependent: :destroy
+
+  # スコープ
+  # active: アクティブなチャットルームのみを取得
+  scope :active, -> { where(status: :active) }
+  # inactive: 非アクティブなチャットルームのみを取得
+  scope :inactive, -> { where(status: :inactive) }
+end 

--- a/app/models/chat_room_user.rb
+++ b/app/models/chat_room_user.rb
@@ -1,0 +1,18 @@
+# チャットルームユーザーモデル
+# チャットルームとユーザーの中間テーブルとして機能するモデル
+class ChatRoomUser < ApplicationRecord
+  # 関連付け
+  # chat_room: 所属するチャットルーム
+  #   - belongs_toで1対多の関係を定義
+  belongs_to :chat_room
+
+  # user: チャットルームに参加しているユーザー
+  #   - belongs_toで1対多の関係を定義
+  belongs_to :user
+
+  # バリデーション
+  # chat_room_id: チャットルームID
+  #   - ユーザーIDとの組み合わせでユニークであることを保証
+  #   - 同じユーザーが同じチャットルームに複数回参加することを防ぐ
+  validates :chat_room_id, uniqueness: { scope: :user_id }
+end 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,19 @@ class User < ApplicationRecord
   has_many :notifications, dependent: :destroy
   has_many :sent_notifications, class_name: 'Notification', foreign_key: 'sender_id', dependent: :destroy
 
+  # チャットルームとの関連付け
+  # チャットルームとの関連付け
+  # chat_room_users: 中間テーブルとの関連
+  #   - ユーザーは複数のチャットルームに参加できる
+  #   - dependent: :destroy により、ユーザーが削除された場合に関連するレコードも削除
+  has_many :chat_room_users, dependent: :destroy
+
+  # chat_rooms: チャットルームとの多対多の関連
+  #   - chat_room_usersを介して関連付け
+  #   - throughオプションで中間テーブルを指定
+  #   - ユーザーは複数のチャットルームに所属でき、チャットルームも複数のユーザーを持つ
+  has_many :chat_rooms, through: :chat_room_users
+
   # 未読通知の有無を確認
   def has_unread_notifications?
     notifications.unread.exists?

--- a/db/migrate/20250327130112_create_chat_rooms.rb
+++ b/db/migrate/20250327130112_create_chat_rooms.rb
@@ -1,0 +1,25 @@
+# チャットルームテーブルを作成するマイグレーションファイル
+# チャットルームは学生と投資家のコミュニケーションの場として使用される
+class CreateChatRooms < ActiveRecord::Migration[8.0]
+  def change
+    # chat_roomsテーブルの作成
+    create_table :chat_rooms do |t|
+      # チャットルーム名（必須項目）
+      t.string :name, null: false
+      
+      # チャットルームの説明文（任意項目）
+      t.text :description
+      
+      # チャットルームのステータス
+      # デフォルト値は0（例：0=開始前、1=進行中、2=終了など）
+      # null: falseで必須項目として設定
+      t.integer :status, default: 0, null: false
+
+      # created_atとupdated_atカラムを自動生成
+      t.timestamps
+    end
+
+    # statusカラムにインデックスを追加し、検索パフォーマンスを向上
+    add_index :chat_rooms, :status
+  end
+end

--- a/db/migrate/20250327130724_create_chat_room_users.rb
+++ b/db/migrate/20250327130724_create_chat_room_users.rb
@@ -1,0 +1,25 @@
+# チャットルームユーザーテーブルを作成するマイグレーションファイル
+# チャットルームとユーザーの中間テーブルとして機能し、多対多の関係を管理する
+class CreateChatRoomUsers < ActiveRecord::Migration[8.0]
+  def change
+    # chat_room_usersテーブルの作成
+    create_table :chat_room_users do |t|
+      # チャットルームの外部キー
+      # null: falseで必須項目として設定
+      # foreign_key: trueで参照整合性を保証
+      t.references :chat_room, null: false, foreign_key: true
+
+      # ユーザーの外部キー
+      # null: falseで必須項目として設定
+      # foreign_key: trueで参照整合性を保証
+      t.references :user, null: false, foreign_key: true
+
+      # created_atとupdated_atカラムを自動生成
+      t.timestamps
+    end
+
+    # chat_room_idとuser_idの組み合わせにユニーク制約を追加
+    # 同じユーザーが同じチャットルームに複数回参加することを防ぐ
+    add_index :chat_room_users, [:chat_room_id, :user_id], unique: true
+  end
+end


### PR DESCRIPTION
   ## 概要
   - チャットルームモデルとユーザーとの関連付けを実装
   - チャットルームのステータス管理機能を追加

   ## 変更内容
   - ChatRoomモデルの作成
     - ステータス管理（active/inactive）
     - バリデーション
     - スコープ
   - ChatRoomUser中間モデルの作成
     - ユーザーとチャットルームの関連付け
     - バリデーション
   - Userモデルへの関連付けの追加

   ## 技術的な詳細
   - マイグレーションファイル
     - create_chat_rooms
     - create_chat_room_users
   - モデル
     - app/models/chat_room.rb
     - app/models/chat_room_user.rb
     - app/models/user.rb（関連付けの追加）

   ## テスト項目
   - [ ] マイグレーションが正常に実行できること
   - [ ] チャットルームの作成が正常に行えること
   - [ ] ユーザーとの関連付けが正しく機能すること
   - [ ] ステータス管理が正しく機能すること