### PR TITLE
feat: メッセージモデルの実装と関連付けの追加

### DIFF
--- a/app/models/chat_room.rb
+++ b/app/models/chat_room.rb
@@ -45,4 +45,26 @@ class ChatRoom < ApplicationRecord
   scope :active, -> { where(status: :active) }
   # inactive: 非アクティブなチャットルームのみを取得
   scope :inactive, -> { where(status: :inactive) }
+
+  #-----------------
+  # メッセージ関連のインスタンスメソッド
+  #-----------------
+
+  # チャットルーム内の最新のメッセージを取得するメソッド
+  # @return [Message, nil] 最新のメッセージ。メッセージが存在しない場合はnil
+  # @note messages.recentスコープを使用して最新順に並び替え、最初の1件を取得
+  def latest_message
+    messages.recent.first
+  end
+
+  # 特定のユーザーに対する未読メッセージの数を取得するメソッド
+  # @param user [User] 未読メッセージをカウントする対象のユーザー
+  # @return [Integer] 未読メッセージの数
+  # @note 
+  #   - messages.unreadスコープで未読メッセージをフィルタリング
+  #   - where.not(user: user)で指定ユーザー以外が送信したメッセージに限定
+  #   - countメソッドで該当するメッセージの数を取得
+  def unread_messages_count(user)
+    messages.unread.where.not(user: user).count
+  end
 end 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,52 @@
+# メッセージモデルクラス
+# チャットルーム内でのメッセージのやり取りを管理するモデル
+# ApplicationRecordを継承して基本的なモデル機能を利用
+class Message < ApplicationRecord
+  #-----------------
+  # 関連付けの定義
+  #-----------------
+  # チャットルームに所属する (1対多の関係)
+  belongs_to :chat_room
+  # ユーザー(送信者)に所属する (1対多の関係)
+  belongs_to :user
+
+  #-----------------
+  # バリデーション
+  #-----------------
+  # メッセージ本文は必須で、1000文字以内に制限
+  validates :content, presence: true, length: { maximum: 1000 }
+  # 既読フラグは真偽値のみ許可
+  validates :is_read, inclusion: { in: [true, false] }
+  # 削除フラグは真偽値のみ許可
+  validates :is_deleted, inclusion: { in: [true, false] }
+
+  #-----------------
+  # スコープの定義
+  #-----------------
+  # 既読メッセージのみを取得
+  scope :read, -> { where(is_read: true) }
+  # 未読メッセージのみを取得
+  scope :unread, -> { where(is_read: false) }
+  # 削除されていないメッセージのみを取得
+  scope :not_deleted, -> { where(is_deleted: false) }
+  # 削除済みメッセージのみを取得
+  scope :deleted, -> { where(is_deleted: true) }
+  # メッセージを作成日時の降順で取得
+  scope :recent, -> { order(created_at: :desc) }
+
+  #-----------------
+  # インスタンスメソッド
+  #-----------------
+  # メッセージを既読状態に更新するメソッド
+  # @return [Boolean] 更新の成功/失敗
+  def mark_as_read!
+    update!(is_read: true)
+  end
+
+  # メッセージを論理削除するメソッド
+  # 物理的な削除は行わず、削除フラグを立てる
+  # @return [Boolean] 更新の成功/失敗
+  def soft_delete!
+    update!(is_deleted: true)
+  end
+end 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,8 +61,38 @@ class User < ApplicationRecord
   #   - ユーザーは複数のチャットルームに所属でき、チャットルームも複数のユーザーを持つ
   has_many :chat_rooms, through: :chat_room_users
 
-  # 未読通知の有無を確認
+  #-----------------
+  # メッセージ関連の関連付け
+  #-----------------
+  # messages: ユーザーが送信したメッセージとの関連付け
+  # - ユーザーは複数のメッセージを送信できる (1対多の関係)
+  # - dependent: :destroy により、ユーザーが削除された場合に関連するメッセージも削除
+  has_many :messages, dependent: :destroy
+
+  #-----------------
+  # 通知関連のインスタンスメソッド
+  #-----------------
+  # 未読通知の有無を確認するメソッド
+  # @return [Boolean] 未読通知が存在する場合はtrue、存在しない場合はfalse
+  # @note 
+  #   - notifications.unreadスコープで未読通知をフィルタリング
+  #   - exists?メソッドで未読通知の存在確認を効率的に行う
   def has_unread_notifications?
     notifications.unread.exists?
+  end
+
+  #-----------------
+  # メッセージ関連のインスタンスメソッド
+  #-----------------
+  # 特定のチャットルームでの未読メッセージ数を取得するメソッド
+  # @param chat_room [ChatRoom] 未読メッセージをカウントする対象のチャットルーム
+  # @return [Integer] 未読メッセージの数
+  # @note
+  #   - chat_room.messagesで対象チャットルームのメッセージを取得
+  #   - unreadスコープで未読メッセージをフィルタリング
+  #   - where.not(user: self)で自分以外のユーザーが送信したメッセージに限定
+  #   - countメソッドで該当するメッセージの数を取得
+  def unread_messages_count_in_chat_room(chat_room)
+    chat_room.messages.unread.where.not(user: self).count
   end
 end

--- a/db/migrate/20250327132630_create_messages.rb
+++ b/db/migrate/20250327132630_create_messages.rb
@@ -1,0 +1,37 @@
+# メッセージテーブルを作成するためのマイグレーションファイル
+# チャットルーム内でのメッセージのやり取りを管理するためのテーブル定義
+class CreateMessages < ActiveRecord::Migration[8.0]
+  def change
+    # messagesテーブルの作成
+    create_table :messages do |t|
+      # メッセージの本文 (必須項目)
+      t.text :content, null: false
+      
+      # チャットルームへの参照 (必須項目)
+      # chat_roomsテーブルへの外部キー制約あり
+      t.references :chat_room, null: false, foreign_key: true
+      
+      # メッセージ送信者(ユーザー)への参照 (必須項目)
+      # usersテーブルへの外部キー制約あり
+      t.references :user, null: false, foreign_key: true
+      
+      # メッセージが既読かどうかのフラグ
+      # デフォルトは未読(false)
+      t.boolean :is_read, default: false, null: false
+      
+      # メッセージが削除されているかどうかのフラグ
+      # 論理削除用のフラグで、デフォルトはfalse
+      t.boolean :is_deleted, default: false, null: false
+
+      # created_at, updated_atのタイムスタンプを自動生成
+      t.timestamps
+    end
+
+    # パフォーマンス向上のためのインデックス
+    # チャットルーム単位でのメッセージ取得を高速化
+    add_index :messages, [:chat_room_id, :created_at]
+    
+    # ユーザー単位でのメッセージ取得を高速化
+    add_index :messages, [:user_id, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_26_144354) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_27_132630) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,39 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_26_144354) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "chat_room_users", force: :cascade do |t|
+    t.bigint "chat_room_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chat_room_id", "user_id"], name: "index_chat_room_users_on_chat_room_id_and_user_id", unique: true
+    t.index ["chat_room_id"], name: "index_chat_room_users_on_chat_room_id"
+    t.index ["user_id"], name: "index_chat_room_users_on_user_id"
+  end
+
+  create_table "chat_rooms", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_chat_rooms_on_status"
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "chat_room_id", null: false
+    t.bigint "user_id", null: false
+    t.boolean "is_read", default: false, null: false
+    t.boolean "is_deleted", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chat_room_id", "created_at"], name: "index_messages_on_chat_room_id_and_created_at"
+    t.index ["chat_room_id"], name: "index_messages_on_chat_room_id"
+    t.index ["user_id", "created_at"], name: "index_messages_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -93,6 +126,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_26_144354) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "chat_room_users", "chat_rooms"
+  add_foreign_key "chat_room_users", "users"
+  add_foreign_key "messages", "chat_rooms"
+  add_foreign_key "messages", "users"
   add_foreign_key "notifications", "posts"
   add_foreign_key "notifications", "users"
   add_foreign_key "notifications", "users", column: "sender_id"


### PR DESCRIPTION
## 概要
- チャットルーム内でのメッセージを管理するためのモデルを実装
- メッセージの既読/未読状態と削除状態の管理機能を追加

## 変更内容
- Messageモデルの作成
  - 基本情報（content, is_read, is_deleted）
  - 関連付け（chat_room, user）
  - バリデーション
  - スコープ
  - ユーティリティメソッド

- ChatRoomモデルの拡張
  - メッセージ関連のメソッド追加
  - 最新メッセージ取得
  - 未読メッセージカウント

- Userモデルの拡張
  - メッセージ関連の関連付け
  - チャットルームごとの未読メッセージカウント

## 技術的な詳細
- マイグレーションファイル
  - create_messages
- モデル
  - app/models/message.rb
  - app/models/chat_room.rb（拡張）
  - app/models/user.rb（拡張）

## テスト項目
- [ ] マイグレーションが正常に実行できること
- [ ] メッセージの作成が正常に行えること
- [ ] 既読/未読状態の管理が正しく機能すること
- [ ] 削除状態の管理が正しく機能すること
- [ ] 関連付けが正しく機能すること