### PR TITLE
feat: チャットルーム一覧表示機能の実装

### DIFF
--- a/app/assets/stylesheets/chat_rooms.scss
+++ b/app/assets/stylesheets/chat_rooms.scss
@@ -162,4 +162,91 @@
       background-color: #0056b3;
     }
   }
+}
+
+// チャットルーム一覧のスタイル
+.chat-rooms-container {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.chat-rooms-title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 2rem;
+  color: #333;
+}
+
+.chat-rooms-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chat-room-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s, box-shadow 0.2s;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  }
+}
+
+.chat-room-info {
+  flex: 1;
+  min-width: 0; // テキストのオーバーフローを防ぐ
+}
+
+.chat-room-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #333;
+}
+
+.latest-message {
+  font-size: 0.9rem;
+  color: #666;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.message-time {
+  font-size: 0.8rem;
+  color: #999;
+  margin-left: 0.5rem;
+}
+
+.no-message {
+  font-size: 0.9rem;
+  color: #999;
+  font-style: italic;
+  margin: 0;
+}
+
+.unread-badge {
+  background-color: #007bff;
+  color: white;
+  font-size: 0.8rem;
+  font-weight: bold;
+  min-width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 1rem;
+  flex-shrink: 0;
 } 

--- a/app/views/chat_rooms/index.html.erb
+++ b/app/views/chat_rooms/index.html.erb
@@ -1,0 +1,36 @@
+<%# チャットルーム一覧ページ %>
+<div class="chat-rooms-container">
+  <h1 class="chat-rooms-title">チャットルーム一覧</h1>
+
+  <%# チャットルーム一覧 %>
+  <div class="chat-rooms-list">
+    <% @chat_rooms.each do |room_data| %>
+      <% chat_room = room_data[:chat_room] %>
+      <% latest_message = room_data[:latest_message] %>
+      <% unread_count = room_data[:unread_count] %>
+
+      <%= link_to chat_room_path(chat_room), class: "chat-room-item" do %>
+        <div class="chat-room-info">
+          <h2 class="chat-room-name"><%= chat_room.name %></h2>
+          <% if latest_message %>
+            <p class="latest-message">
+              <%= latest_message.content %>
+              <span class="message-time">
+                <%= time_ago_in_words(latest_message.created_at) %>前
+              </span>
+            </p>
+          <% else %>
+            <p class="no-message">メッセージはまだありません</p>
+          <% end %>
+        </div>
+
+        <%# 未読メッセージ数 %>
+        <% if unread_count > 0 %>
+          <div class="unread-badge">
+            <%= unread_count %>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,8 @@ Rails.application.routes.draw do
 
   # チャットルームのルーティング
   # チャットルーム関連のルーティング設定
-  resources :chat_rooms, only: [:create, :show] do
+  resources :chat_rooms, only: [:index, :create, :show] do
+    # - indexアクション: チャットルーム一覧の表示 (GET /chat_rooms)
     # - createアクション: 新規チャットルームの作成 (POST /chat_rooms)
     # - showアクション: 個別のチャットルームの表示 (GET /chat_rooms/:id)
     


### PR DESCRIPTION
- チャットルーム一覧の表示機能を追加

- 最新メッセージの表示機能を追加

- 未読メッセージ数の表示機能を追加

- 作成日時順のソート機能を追加

- チャットルーム一覧のスタイリングを実装

タイトル：
feat: チャットルーム一覧表示機能の実装

説明：
チャットルーム一覧を表示する機能を実装しました。ユーザーが参加しているチャットルームを一覧で表示し、最新メッセージや未読数を確認できるようになりました。

実装内容：
1. チャットルーム一覧の表示
   - ユーザーが参加しているチャットルームを表示
   - 作成日時の降順でソート

2. 最新メッセージの表示
   - 各チャットルームの最新メッセージを表示
   - メッセージがない場合は「メッセージはまだありません」と表示

3. 未読メッセージ数の表示
   - 未読メッセージがある場合、バッジで表示
   - 未読メッセージがない場合は表示しない

4. スタイリング
   - モダンでレスポンシブなデザイン
   - ホバーエフェクト
   - 未読バッジのスタイリング

変更ファイル：
- app/controllers/chat_rooms_controller.rb
- app/views/chat_rooms/index.html.erb
- app/assets/stylesheets/chat_rooms.scss
- config/routes.rb