### PR TITLE
Add documentation for CI/CD fixes completed on April 16, 2025：CI/CDパイプラインの修正ドキュメント（2025年4月16日）

### DIFF
--- a/docs/ci-fixes-2025-04-16.md
+++ b/docs/ci-fixes-2025-04-16.md
@@ -1,0 +1,77 @@
+# CI/CDパイプライン修正作業記録 (2025年4月16日)
+
+## 概要
+
+GitHub Actions CI/CDパイプラインで発生していた「Some checks were not successful」エラーを修正しました。
+具体的には以下の3つのエラーを解消しました：
+
+1. コードスタイル違反（Rubocop）
+2. Rubyセキュリティスキャン（Brakeman）のエラー
+3. JavaScriptセキュリティスキャン（importmap audit）のエラー
+
+## 修正内容
+
+### 1. コードスタイル違反の修正
+
+Rubocopを使用して、コードスタイルの問題を自動修正しました。主な問題は：
+
+- 文字列のクォートスタイル（シングルクォート vs ダブルクォート）
+- 配列内のスペース
+- 行末の余分なスペース
+- ファイルの最後の改行の欠如
+
+```bash
+docker-compose exec web bin/rubocop -a
+```
+
+### 2. Brakemanの更新
+
+Rubyセキュリティスキャンツールのバージョンを7.0.0から7.0.2にアップデートしました：
+
+```bash
+docker-compose exec web bundle update brakeman
+```
+
+### 3. JavaScriptセキュリティスキャンの修正
+
+`bin/importmap audit`コマンドの実行に問題があったため、CIパイプラインを修正してnpm auditを使用するように変更しました：
+
+```yaml
+# 変更前
+- name: Set up Ruby
+  uses: ruby/setup-ruby@v1
+  with:
+    ruby-version: .ruby-version
+    bundler-cache: true
+
+- name: Scan for security vulnerabilities in JavaScript dependencies
+  run: bin/importmap audit
+
+# 変更後
+- name: Set up Node.js
+  uses: actions/setup-node@v3
+  with:
+    node-version: '18'
+    cache: 'npm'
+
+- name: Scan for security vulnerabilities in JavaScript dependencies
+  run: npm audit
+```
+
+また、ローカル環境でスクリプトを実行できるように`bin/importmap`に実行権限を付与しました：
+
+```bash
+chmod +x bin/importmap
+```
+
+## 学んだこと
+
+1. **CI/CDパイプラインの重要性**: 自動化されたテストとコード品質チェックにより、早期に問題を発見できます
+2. **セキュリティスキャンの意義**: アプリケーションの脆弱性を定期的にチェックすることの重要性
+3. **適切なツールの選択**: 問題解決には、時に代替ツールや方法を検討する柔軟性が必要
+
+## 今後の課題
+
+1. テスト環境の整備（RSpecとMinitestの不一致を解決）
+2. セキュリティスキャンの定期的な実行体制の構築
+3. AWS環境へのデプロイに向けたCI/CDパイプラインの拡張 


### PR DESCRIPTION
# CI/CDパイプライン修正作業の記録

このプルリクエストは、2025年4月16日に実施したCI/CDパイプラインの修正作業を記録するためのドキュメントを追加するものです。

## 実施した修正
- Rubocopによるコードスタイル違反の修正
- Brakemanの最新バージョンへの更新（セキュリティスキャン）
- JavaScriptセキュリティスキャンのnpm auditへの変更
- bin/importmapに実行権限を付与

## 注意
このPRは記録用であり、修正自体はすでにmainブランチに適用されています。