### PR TITLE
Fix/ci errors：Rubocopの設定を更新

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,19 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
 #   Enabled: false
+
+# 文字列リテラルはダブルクォートを使用
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+# 配列リテラル内のスペースを強制
+Layout/SpaceInsideArrayLiteralBrackets:
+  EnforcedStyle: space
+
+# 末尾の空白を禁止
+Layout/TrailingWhitespace:
+  Enabled: true
+
+# ファイルの末尾に空行を強制
+Layout/TrailingEmptyLines:
+  Enabled: true

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -8,4 +8,4 @@ class RegistrationsController < Devise::RegistrationsController
   def account_update_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation, :current_password, :bio, :avatar)
   end
-end 
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -33,6 +33,6 @@ class Post < ApplicationRecord
   scope :recent, -> { newest }
   scope :by_category, ->(category) { where(category: category) }
   scope :search, ->(query) {
-    where('title LIKE :query OR content LIKE :query', query: "%#{query}%")
+    where("title LIKE :query OR content LIKE :query", query: "%#{query}%")
   }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
 
   # プロフィール画像の関連付け
   has_one_attached :avatar
-  validates :avatar, content_type: { in: ['image/png', 'image/jpeg'] },
+  validates :avatar, content_type: { in: [ "image/png", "image/jpeg" ] },
                     size: { less_than: 5.megabytes }
 
   # 投稿との関連付け


### PR DESCRIPTION
# Rubocopの設定を更新

## 変更内容
- 文字列リテラルをダブルクォートに統一する設定を追加
- 配列リテラル内のスペースを強制する設定を追加
- 末尾の空白を禁止する設定を追加
- ファイルの末尾に空行を強制する設定を追加

## 目的
CI環境とローカル環境でのRubocopの動作を一致させ、コードスタイルの一貫性を保つため。

## 影響範囲
- `.rubocop.yml`ファイルの設定変更
- これにより、CIでのRubocopチェックが正常に動作するようになります

## テスト
- ローカル環境で`bundle exec rubocop`を実行し、エラーが発生しないことを確認
- CIでのRubocopチェックが正常に通過することを確認

## 備考
この変更はコードの機能には影響せず、スタイルチェックの設定のみを更新するものです。